### PR TITLE
Bump iac-modules

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -163,7 +163,7 @@ pipeline {
                     ansible-galaxy install geerlingguy.docker,3.0.0 --force
                     ansible-galaxy install geerlingguy.repo-epel,3.0.0 --force
                     rm -r -f openstack-blueprint/modules/
-                    git clone -b 3.2.1 https://github.com/SODALITE-EU/iac-modules.git openstack-blueprint/modules/
+                    git clone -b 3.4.1 https://github.com/SODALITE-EU/iac-modules.git openstack-blueprint/modules/
                     cp ${ca_crt_file} openstack-blueprint/modules//docker/artifacts/ca.crt
                     cp ${ca_crt_file} openstack-blueprint/modules//misc/tls/artifacts/ca.crt
                     cp ${ca_key_file} openstack-blueprint/modules//docker/artifacts/ca.key


### PR DESCRIPTION
This contribution bumps iac-modules in CI/CD pipeline. New modules' version provides pip docker bugfix for deployment to centos7 distribution