### PR TITLE
Add --online flag for pytest to run tests directly against online services

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ All the requirements are stated in "requirements.txt".
 2. Run tests
    `pytest`
 
+*Note*: some tests require online services to be available (like the MODAK component) and are skipped by default.
+Use `pytest --online` to include those tests in the test run.
+Currently all of the online tests are also available as mocked tests (meaning they use pre-recorderd replies, for example to verify the parser).
+
 ## Docker
 
 Currently the container is accessible from:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -73,3 +73,24 @@ def get_workdir_path():
     os.makedirs(workdir_path)
     yield workdir_path
     shutil.rmtree(workdir_path)
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--online", action="store_true", default=False,
+        help="run tests requiring online services to be available (may need additional configuration)"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "online: mark test as requiring an online service")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--online"):
+        return
+
+    skip_online = pytest.mark.skip(reason="need --online option to run")
+    for item in items:
+        if "online" in item.keywords:
+            item.add_marker(skip_online)

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -152,8 +152,8 @@ def test_node_template_details(json_in,yaml_out):
                         if isinstance(value_pro, dict) and "value" in value_pro.keys() and "label" in value_pro.keys():
                             node_pro = node_out.get("properties").get(value_pro["label"])
                             if isinstance(node_pro, dict):
-                                key_v = re.search('{\s(.+?):', value_pro["value"]).group(1)
-                                value_v = re.search(':\s(.+?)\s}', value_pro["value"]).group(1)
+                                key_v = re.search(r'{\s(.+?):', value_pro["value"]).group(1)
+                                value_v = re.search(r':\s(.+?)\s}', value_pro["value"]).group(1)
                                 assert key_v in node_pro.keys() and value_v in node_pro.values(),"properties error with label and value"
                                 pass #later
                             elif isinstance(node_pro, list):
@@ -277,9 +277,8 @@ def mock_modak_get_opt_job_content(app, target, job_options, opt_json_string):
         request_gpus=job_options.get("request_gpus"), core_count=job_options.get("core_count"))
 
 
-def test_parser_opt(mocker):
-
-    mocker.patch('src.iacparser.ModakConfig.get_opt_image', new=mock_modak_get_opt_image)
+@pytest.mark.online
+def test_parser_opt():
 
     # this component has optimisation field
     opt_component = "optimization-skyline-extractor"
@@ -308,10 +307,15 @@ def test_parser_opt(mocker):
     assert not "optimization" in opt_not_found_component_template
     assert image_name == opt_not_found_expected_container_runtime
 
-def test_parser_opt_job(mocker):
+
+def test_parser_opt_offline(mocker):
 
     mocker.patch('src.iacparser.ModakConfig.get_opt_image', new=mock_modak_get_opt_image)
-    mocker.patch('src.iacparser.ModakConfig.get_opt_job_content', new=mock_modak_get_opt_job_content)
+    test_parser_opt()
+
+
+@pytest.mark.online
+def test_parser_opt_job():
 
     # this component has optimisation field
     opt_component = "batch-app"
@@ -342,10 +346,16 @@ def test_parser_opt_job(mocker):
     assert "#PBS -l nodes=1:gpus=1:ssd" in content
     assert "#PBS -l procs=40" in content
 
-def test_parser_no_opt_job(mocker):
+
+def test_parser_opt_job_offline(mocker):
 
     mocker.patch('src.iacparser.ModakConfig.get_opt_image', new=mock_modak_get_opt_image)
     mocker.patch('src.iacparser.ModakConfig.get_opt_job_content', new=mock_modak_get_opt_job_content)
+    test_parser_opt_job()
+
+
+@pytest.mark.online
+def test_parser_no_opt_job():
 
     # this component has optimisation field
     no_opt_component = "no-opt-batch-app"
@@ -375,6 +385,14 @@ def test_parser_no_opt_job(mocker):
     assert "#PBS -q ssd" in content
     assert "#PBS -l nodes=1:gpus=1:ssd" in content
     assert "#PBS -l procs=40" in content
+
+
+def test_parser_no_opt_job_offline(mocker):
+
+    mocker.patch('src.iacparser.ModakConfig.get_opt_image', new=mock_modak_get_opt_image)
+    mocker.patch('src.iacparser.ModakConfig.get_opt_job_content', new=mock_modak_get_opt_job_content)
+    test_parser_no_opt_job()
+
 
 def test_parser_tosca_capabilities():
 


### PR DESCRIPTION
This helps with integration testing to directly run the tests against a newer version of MODAK.