### PR TITLE
Push to dockerhub during staging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
         flavor_name = "m1.medium"
         // DOCKER SETTINGS
         docker_network = "sodalite"
-        docker_registry_ip = credentials('jenkins-docker-registry-ip')
+        //docker_registry_ip = credentials('jenkins-docker-registry-ip')
         docker_public_registry_url = "registry.hub.docker.com"
         xopera_endpoint = credentials('xopera-http-endpoint')
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,20 +108,19 @@ pipeline {
                     """
             }
         }
-        stage('Push iac-blueprint-builder to sodalite-private-registry') {
-            // Push during staging and production
+        stage('Push iac-blueprint-builder to DockerHub for staging') {
             when {
                 allOf {
                     expression{tag "*"}
                     expression{
-                        TAG_STAGING == 'true' || TAG_PRODUCTION == 'true'
+                        TAG_STAGING == 'true'
                     }
                 }
             }
             steps {
                 withDockerRegistry(credentialsId: 'jenkins-sodalite.docker_token', url: '') {
                     sh  """#!/bin/bash
-                        ./make_docker.sh push iac-blueprint-builder staging
+                        ./make_docker.sh push iac-blueprint-builder sodaliteh2020 staging
                         """
                 }
             }
@@ -139,7 +138,7 @@ pipeline {
             steps {
                 withDockerRegistry(credentialsId: 'jenkins-sodalite.docker_token', url: '') {
                     sh  """#!/bin/bash
-                            ./make_docker.sh push iac-blueprint-builder production
+                            ./make_docker.sh push iac-blueprint-builder sodaliteh2020 production
                         """
                 }
             }

--- a/make_docker.sh
+++ b/make_docker.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
+
+# make_docker V2
 #
 # Build or push an image.
-# Images for staging are pushed to sodalite-private-registry on ${docker_registry_ip}
-# Images with production-ready version are pushed to both sodalite-private-registry and dockerhub: sodaliteh2020 repository
 
-# Images from tagged commits are tagged with git tag
-# Images from non-tagged commits are tagged with <last_git_tag>-<commits_since_tag>-<abbreviated_commit_sha>
+# Images from non-tagged commits are versioned by <last_git_tag>-<commits_since_tag>-<abbreviated_commit_sha>
+# Images from tagged commits are versioned by git tag
+
+# Images for staging are tagged and pushed only with ${VERSION}
+# Images for production are tagged and pushed with both tags: latest and ${VERSION}
+
 #
 # Usage:
 #   $0 build <image-name> [Dockerfile-filename]
-#   $0 push <image-name> [production|staging]
+#   $0 push <image-name> <target-registry> [production|staging]
 # image name is pure name without repository (image-name, not sodaliteh2020/image-name)
 
 build() {
@@ -19,42 +23,39 @@ build() {
 }
 
 push() {
-
     set -x
     docker tag "${IMAGE}":latest "${TARGET_REGISTRY}/${IMAGE}:${VERSION}"
-    docker tag "${IMAGE}":latest "${TARGET_REGISTRY}/${IMAGE}:latest"
     docker push "${TARGET_REGISTRY}/${IMAGE}:${VERSION}"
-    docker push "${TARGET_REGISTRY}/${IMAGE}:latest"
     set +x
+
+    if [[ "$TARGET" = 'production' ]]; then
+      set -x
+      docker tag "${IMAGE}":latest "${TARGET_REGISTRY}/${IMAGE}:latest"
+      docker push "${TARGET_REGISTRY}/${IMAGE}:latest"
+      set +x
+    fi
+
 }
 
 
-if [[ $# -gt 3 ]] || [[ $# -lt 2 ]] || \
-   [[ "$1" != "build" && "$1" != "push" ]] || \
-   [[ "$1" = "push" && "$3" != "staging" && "$3" != "production" ]]; then
+if [[ "$1" != "build" && "$1" != "push" ]] || \
+   [[ "$1" = "build" ]] && [[ $# -gt 3 || $# -lt 2 ]] || \
+   [[ "$1" = "push" ]] && [[ $# -gt 4 || $# -lt 3 ]] && [[ "$4" != "staging" && "$4" != "production" ]]; then
 
     echo "Usage: $0 build <image-name> [Dockerfile-filename]"
-    echo "Usage: $0 push <image-name> [production|staging]"
+    echo "Usage: $0 push <image-name> <target-registry> [production|staging]"
     exit 1
 fi
 
-git fetch --tags
-
+git fetch --tags -f
 ACTION=$1
 IMAGE=$2
 if [ "$ACTION" = 'build' ];
   then
     FILE=${3:-Dockerfile}
   else
-    TARGET=${3:-staging}
-fi
-
-if [[ "$ACTION" = 'push' ]]; then
-  if [[ "$TARGET" = 'production' ]]; then
-    TARGET_REGISTRY=sodaliteh2020
-  else
-    TARGET_REGISTRY=${docker_registry_ip:-localhost}
-  fi
+    TARGET_REGISTRY=$3
+    TARGET=${4:-staging}
 fi
 
 VERSION=$(git describe --tag --always | sed -e"s/^v//")
@@ -62,17 +63,27 @@ DATE=$(date -u +%Y-%m-%dT%H:%M:%S)
 
 # debug section
 echo "make_docker.sh:"
+echo
+echo "---------------"
 echo "ACTION: $ACTION"
+if [ "$ACTION" = 'push' ]; then
+  echo "TARGET: $TARGET"
+  echo "TARGET_REGISTRY: $TARGET_REGISTRY"
+fi
 echo "IMAGE: $IMAGE"
-echo "FILE: $FILE"
+if [ "$ACTION" = 'build' ]; then
+  echo "FILE: $FILE"
+fi
 echo "VERSION: $VERSION"
 echo "DATE: $DATE"
-echo "TARGET: $TARGET"
-echo "TARGET_REGISTRY: $TARGET_REGISTRY"
 
+echo "---------------"
+echo
 
 if [ "$ACTION" = "build" ]; then
     build
 else
     push
 fi
+
+echo


### PR DESCRIPTION
This PR modifies CI/CD pipeline in a way that staging images are pushed to dockerhub instead to SODALITE private registry.

Changes:

- make_docker.sh
  - enable manual spec of target registry
- Jenkinsfile
  - Push images to docker hub for both staging and production