### PR TITLE
Adding tests for ModakConfig and building the IaC Builder with MODAK env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
 FROM python:3.8.10
+
+ENV MODAK_ENDPOINT "http://modak.sodalite.eu:5000"
+ENV MODAK_API_IMAGE "/get_image"
+ENV MODAK_API_JOB "/get_job_content"
+
 ADD . /parser
 WORKDIR /parser
 RUN pip3 install -r requirements.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
         //docker_registry_ip = credentials('jenkins-docker-registry-ip')
         docker_public_registry_url = "registry.hub.docker.com"
         xopera_endpoint = credentials('xopera-http-endpoint')
+        modak_endpoint = "http://modak.sodalite.eu:5000"
 
         // OPENSTACK DEPLOYMENT SETTINGS
         OS_PROJECT_DOMAIN_NAME = "Default"

--- a/config_modak.json
+++ b/config_modak.json
@@ -1,5 +1,5 @@
 {
-    "MODAK_ENDPOINT" : "http://77.231.202.209:5000",
+    "MODAK_ENDPOINT" : "http://modak.sodalite.eu:5000",
     "MODAK_API_IMAGE" : "/get_image",
     "MODAK_API_JOB" : "/get_job_content"
 }

--- a/openstack-blueprint/input.yaml.tmpl
+++ b/openstack-blueprint/input.yaml.tmpl
@@ -12,3 +12,4 @@ docker-public-registry-url: ${docker_public_registry_url}
 # IAC_BLUEPRINT_BUILDER SETTINGS
 iac-blueprint-builder_env:
   XOPERA_ENDPOINT: ${xopera_endpoint}
+  MODAK_ENDPOINT: ${modak_endpoint}

--- a/test/artifacts.json
+++ b/test/artifacts.json
@@ -1,0 +1,188 @@
+{
+    "https://www.sodalite.eu/ontologies/workspace/1/shqgpbhpr11hf37923gunuksoh/AADM_dfg2fmr1m7qj4lh0acos3o6g73": {
+      "id": "https://www.sodalite.eu/ontologies/workspace/1/shqgpbhpr11hf37923gunuksoh/AADM_dfg2fmr1m7qj4lh0acos3o6g73",
+      "namespace": "datapipeline",
+      "type": "AbstractApplicationDeploymentModel",
+      "createdBy": "https://www.sodalite.eu/ontologies/workspace/1/shqgpbhpr11hf37923gunuksoh/27827d44-0f6c-11ea-8d71-362b9e155667",
+      "createdAt": "2022-01-10T14:29:19.136Z",
+      "participants": [
+        "https://www.sodalite.eu/ontologies/workspace/1/datapipeline/webcam-consumer",
+        "https://www.sodalite.eu/ontologies/workspace/1/datapipeline/s3-publisher"
+      ]
+    },
+    "https://www.sodalite.eu/ontologies/workspace/1/datapipeline/sodalite.nodes.datapipeline.Consumer.HTTP.JsonList": {
+      "type": "https://www.sodalite.eu/ontologies/workspace/1/datapipeline/sodalite.nodes.datapipeline.PipelineBlock.Consumer",
+      "isNodeTemplate": false,
+      "class": "node_types",
+      "properties": [
+        {
+          "https://www.sodalite.eu/ontologies/tosca/name": {
+            "description": "Name of the pipeline node",
+            "specification": {
+              "type": {
+                "https://www.sodalite.eu/ontologies/tosca/string": {
+                  "label": "string"
+                }
+              },
+              "required": true
+            }
+          }
+        }
+      ],
+      "attributes": [
+        {
+          "https://www.sodalite.eu/ontologies/tosca/tosca_name": {
+            "description": "Reflects the name of the Node Template as defined in the TOSCA service template. This name is not unique to the realized instance model of corresponding deployed application as each template in the model can result in one or more instances (e.g., scaled) when orchestrated to a provider environment.",
+            "specification": {
+              "type": {
+                "https://www.sodalite.eu/ontologies/tosca/string": {
+                  "label": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "https://www.sodalite.eu/ontologies/workspace/1/datapipeline/template_id": {
+            "specification": {
+              "type": {
+                "https://www.sodalite.eu/ontologies/tosca/string": {
+                  "label": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "https://www.sodalite.eu/ontologies/workspace/1/datapipeline/pipeline_id": {
+            "specification": {
+              "type": {
+                "https://www.sodalite.eu/ontologies/tosca/string": {
+                  "label": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "https://www.sodalite.eu/ontologies/tosca/tosca_id": {
+            "description": "A unique identifier of the realized instance of a Node Template that derives from any TOSCA normative type",
+            "specification": {
+              "type": {
+                "https://www.sodalite.eu/ontologies/tosca/string": {
+                  "label": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "https://www.sodalite.eu/ontologies/tosca/state": {
+            "description": "The state of the node instance.",
+            "specification": {
+              "type": {
+                "https://www.sodalite.eu/ontologies/tosca/string": {
+                  "label": "string"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "artifacts": [
+        {
+          "https://www.sodalite.eu/ontologies/workspace/1/datapipeline/ConHTTPJsonList_Template": {
+            "specification": {
+              "url": "http://160.40.52.200:8080/Ansibles/dc9d6683-47c9-47d0-a266-7bcf346ef2ae",
+              "type": {
+                "https://www.sodalite.eu/ontologies/tosca/tosca.artifacts.File": {
+                  "label": "tosca.artifacts.File"
+                }
+              },
+              "path": "/home/test/sodalite/ConHTTPJsonList_Local.xml"
+            }
+          }
+        }
+      ]
+    },
+    "https://www.sodalite.eu/ontologies/workspace/1/datapipeline/sodalite.nodes.datapipeline.Publisher.S3Bucket": {
+      "type": "https://www.sodalite.eu/ontologies/workspace/1/datapipeline/sodalite.nodes.datapipeline.PipelineBlock.Publisher",
+      "isNodeTemplate": false,
+      "class": "node_types",
+      "attributes": [
+        {
+          "https://www.sodalite.eu/ontologies/tosca/tosca_id": {
+            "description": "A unique identifier of the realized instance of a Node Template that derives from any TOSCA normative type",
+            "specification": {
+              "type": {
+                "https://www.sodalite.eu/ontologies/tosca/string": {
+                  "label": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "https://www.sodalite.eu/ontologies/workspace/1/datapipeline/pipeline_id": {
+            "specification": {
+              "type": {
+                "https://www.sodalite.eu/ontologies/tosca/string": {
+                  "label": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "https://www.sodalite.eu/ontologies/tosca/state": {
+            "description": "The state of the node instance.",
+            "specification": {
+              "type": {
+                "https://www.sodalite.eu/ontologies/tosca/string": {
+                  "label": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "https://www.sodalite.eu/ontologies/tosca/tosca_name": {
+            "description": "Reflects the name of the Node Template as defined in the TOSCA service template. This name is not unique to the realized instance model of corresponding deployed application as each template in the model can result in one or more instances (e.g., scaled) when orchestrated to a provider environment.",
+            "specification": {
+              "type": {
+                "https://www.sodalite.eu/ontologies/tosca/string": {
+                  "label": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "https://www.sodalite.eu/ontologies/workspace/1/datapipeline/template_id": {
+            "specification": {
+              "type": {
+                "https://www.sodalite.eu/ontologies/tosca/string": {
+                  "label": "string"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "artifacts": [
+        {
+          "https://www.sodalite.eu/ontologies/workspace/1/datapipeline/PubS3Bucket_Template": {
+            "specification": {
+              "type": {
+                "https://www.sodalite.eu/ontologies/tosca/tosca.artifacts.File": {
+                  "label": "tosca.artifacts.File"
+                }
+              },
+              "path": "/home/test/sodalite/PubS3Bucket_Local.xml",
+              "url": "http://160.40.52.200:8080/Ansibles/137006d0-b3c7-438a-b81d-3755f3894f8f"
+            }
+          }
+        }
+      ]
+    }
+  }

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -117,6 +117,25 @@ def test_artifacts_extraction():
         exs.append(expected[i])
     assert exs == pds
 
+def test_tosca_artifacts():
+    expected = ([], [],
+
+                ['http://160.40.52.200:8080/Ansibles/dc9d6683-47c9-47d0-a266-7bcf346ef2ae',
+                 'http://160.40.52.200:8080/Ansibles/137006d0-b3c7-438a-b81d-3755f3894f8f'],
+
+                ['sodalite/ConHTTPJsonList_Local.xml',
+                 'sodalite/PubS3Bucket_Local.xml'])
+
+    test = TestConfig("fixture", "test/artifacts.json")
+
+    parsed_data = parser.parse_data(test.parser_dest(), test.fixture())
+    pds = []
+    exs = []
+    for i in range(0, 3):
+        pds.append(parsed_data[i])
+        exs.append(expected[i])
+    assert exs == pds
+
 #checking if the output file is sucssesful generated
 def test_output_path(test_fixture):
     assert Path.exists(test_fixture.yaml_path()),"output yaml not found"


### PR DESCRIPTION
This PR adds additional tests to ModakConfig class and changes building configuration by introducing env variables for the Modak endpoints. Default Modak endpoint is the one reachable with domain name: http://modak.sodalite.eu:5000